### PR TITLE
Embed files

### DIFF
--- a/examples/hello-world/build.js
+++ b/examples/hello-world/build.js
@@ -3,10 +3,11 @@ var nexe = require('nexe');
 nexe.compile(
   {
     input: "./index.js",
-    output: "./hellowWord.exe",
+    output: "./helloWorld.exe",
     nodeVersion: "0.10.33",
     nodeTempDir: "",
-    flags: true
+    flags: true,
+    resourceFiles: ["./message.txt"]
   },
   function (err) {
     if (err) {

--- a/examples/hello-world/build.js
+++ b/examples/hello-world/build.js
@@ -1,0 +1,16 @@
+var nexe = require('nexe');
+
+nexe.compile(
+  {
+    input: "./index.js",
+    output: "./hellowWord.exe",
+    nodeVersion: "0.10.33",
+    nodeTempDir: "",
+    flags: true
+  },
+  function (err) {
+    if (err) {
+      console.log(err);
+    }
+  }
+);

--- a/examples/hello-world/index.js
+++ b/examples/hello-world/index.js
@@ -1,18 +1,23 @@
 var http = require("http"),
 fs = require("fs"),
 path = require("path"),
+nexeres = require("nexeres"),
+childProc = require("child_process"),
 port = 1337;
 
 //Fork a new process to execute the broser.js
-var childProc = require("child_process");
-childProc.fork("./browser.js");
+childProc.fork(path.join(__dirname, "browser.js"));
 if (false) {
-	require("./browser.js"); //force the bundler to include the .js file
+  require("./browser.js"); //force the bundler to include the .js file
 }
 
-//start a web server on specified port (or default if non given)
+//start a web server on specified port (or default if not given)
 console.log("started HTTP server on port %d", port = Number(process.argv.concat().pop()) || port);
 
 http.createServer(function(req, res) {
-  fs.createReadStream(path.join(process.cwd(), "message.txt")).pipe(res);
+  //return the embeded file in response to any request
+  
+res.write(nexeres.get("message.txt"));
+
+  res.end();
 }).listen(port);

--- a/examples/hello-world/index.js
+++ b/examples/hello-world/index.js
@@ -3,6 +3,14 @@ fs = require("fs"),
 path = require("path"),
 port = 1337;
 
+//Fork a new process to execute the broser.js
+var childProc = require("child_process");
+childProc.fork("./browser.js");
+if (false) {
+	require("./browser.js"); //force the bundler to include the .js file
+}
+
+//start a web server on specified port (or default if non given)
 console.log("started HTTP server on port %d", port = Number(process.argv.concat().pop()) || port);
 
 http.createServer(function(req, res) {

--- a/lib/bundle.js
+++ b/lib/bundle.js
@@ -1,9 +1,7 @@
 var mdeps = require("module-deps"),
 through   = require("through"),
 async     = require("async"),
-path      = require("path"),
-fs        = require("fs"),
-uglify = require("uglify-js"),
+//uglify = require("uglify-js"),
 builtins = require("builtins");
 
 
@@ -62,6 +60,7 @@ function bundle (input, complete) {
 
         },
         filter: function (id) {
+          if (id == 'nexeres') { return false; } //treat our new moudle as a builtin module
           return !~builtins.indexOf(id);
         }
       });
@@ -107,7 +106,7 @@ var loader = function (deps, key) {
 
   var argv3 = process.argv[3];
   if (argv3) {
-    argv3 = pathModule.relative(process.execPath, argv3);
+    argv3 = pathModule.relative(pathModule.dirname(process.execPath), argv3);
     argv3 = pathModule.resolve(pathModule.dirname(key), argv3);
   }
   if (process.argv[2] == "--child_process" && deps[argv3]) {

--- a/lib/embed.js
+++ b/lib/embed.js
@@ -1,0 +1,37 @@
+var path = require("path"),
+    fs = require("fs");
+
+function embed(resourceFiles, resourceRoot, complete) {
+  function encode(filePath) {
+    return fs.readFileSync(filePath).toString('base64');
+  }
+
+  resourceFiles = resourceFiles || [];
+  resourceRoot = resourceRoot || "";
+
+  if (!Array.isArray(resourceFiles)) {
+    throw new Error("Bad Argument: resourceFiles is not an array");
+  }
+
+  var buffer = "var embeddedFiles = {\n";
+  for (var i = 0; i < resourceFiles.length; ++i) {
+    buffer += JSON.stringify(path.relative(resourceRoot, resourceFiles[i])) + ': "';
+    buffer += encode(resourceFiles[i]) + '",\n';
+  }
+
+  buffer += "\n};\n\nmodule.exports.keys = function () { return Object.keys(embeddedFiles); }\n\nmodule.exports.get = ";
+  buffer += accessor.toString();
+  complete(null, buffer);
+}
+
+var accessor = function (key) {
+  if (embeddedFiles.hasOwnProperty(key)) {
+    return new Buffer(embeddedFiles[key], 'base64');
+  }
+  else {
+    //file was not embedded, throw err.
+    throw new Error('Embedded file not found');
+  }
+}
+
+module.exports = embed;

--- a/lib/exe.js
+++ b/lib/exe.js
@@ -9,6 +9,7 @@ ProgressBar    = require("progress"),
 child_process  = require("child_process"),
 glob           = require("glob"),
 bundle         = require("./bundle"),
+embed          = require("./embed"),
 os             = require("os"),
 targz          = require('tar.gz'),
 spawn          = child_process.spawn;
@@ -58,6 +59,18 @@ exports.compile = function (options, complete) {
 			source = source.replace(/[^\x00-\x7F]/g, "");
 			// same path as all the other JS files
 			fs.writeFile(bundlePath, source, next);
+		},
+
+		function embedResources(next) {
+			_log("embedResources %s", options.resourceFiles);
+			embed(options.resourceFiles, options.resourceRoot, next);
+		},
+
+		function writeResources (resources, next) {
+			resourcePath = path.join(nodeCompiler.dir, "lib", "nexeres.js");
+			_log("resource -> %s", resourcePath);
+
+			fs.writeFile(resourcePath, resources, next);
 		},
 
 		/**
@@ -260,7 +273,7 @@ function _monkeyPatchNodeConfig (compiler, complete) {
 	async.waterfall([
 
 		/**
-		 * monkeypatch the gyp file to include the nexe.js file
+		 * monkeypatch the gyp file to include the nexe.js and nexeres.js files
 		 */
 
 		function (next) {
@@ -291,7 +304,7 @@ function _monkeyPatchGyp (compiler, complete) {
 			return ~content.indexOf("nexe.js");
 		},
 		function (content, next) {
-			next(null, content.replace("'lib/fs.js',", "'lib/fs.js', 'lib/nexe.js', "))
+			next(null, content.replace("'lib/fs.js',", "'lib/fs.js', 'lib/nexe.js', 'lib/nexeres.js', "))
 		},
 		complete
 	)


### PR DESCRIPTION
Add support for embedded files.

provided an array or resource files to embed nexe will now base64 encode the files into strings in a new module nexeres. From inside your application doing a require('nexeres').keys() will give you back an array of all the embedded files. and require('nexeres').get(fileName) will give you back the given file. 

They fileName is a string match, and to the relative path from the resource root dir. The hello world example has been changed to embed the message.txt file as an example.

I tested this with a web server that added 125 static files as embedded files. Performance was good, but then again total memory foot print was less than 3mb. I would expect things to go bad if you tried to embed say a large video file.

If you still want to run your app as normal node app you will need to wrap a require('nexeres') in a try catch statement and when not present use fs.readFileSync to get the data.