### PR TITLE
Make process.argv consistent in the child fork case

### DIFF
--- a/lib/bundle.js
+++ b/lib/bundle.js
@@ -113,12 +113,12 @@ var loader = function (deps, key) {
   if (process.argv[2] == "--child_process" && deps[argv3]) {
     //we've been forked and should run the module specified by argv3[3] instead of the start up module
     key = argv3;
-    process.argv = process.argv.splice(2, 2);
+    process.argv.splice(2, 2); //restore the argv to [0] = executable, [1] = nexejs
   }
   else if (process.argv[2] == "--child_process") {
     //fork called, but for a module not bundled.
     argv3 = process.argv[3];
-    process.argv = process.argv.splice(2, 2);
+    process.argv.splice(1, 2); //restore the argv to [0] = executable, [1] = script
     global.require(argv3);
     return;
   }


### PR DESCRIPTION
This will fix an oversight that caused a bug when forking a child process. The process.argv are not correct for the child proc.

The main process
process.argv[0] = the nexe compiled executable
process.argv[1] = nexe.js

The child process forked from a bundled script should be the same
process.argv[0] = the nexe compiled executable
process.argv[1] = nexe.js
(before this fix, argv[0] == '--child_process', argv[1]=='forkedScript.js')

The child process forked to an external .js file should be
process.argv[0] = the nexe compiled executable
process.argv[1] = theForkedScript.js
(before this fix, argv[0] == '--child_process')

This is consistent, and will allow any node module to always get the running executable by looking at process.argv[0]