### PR TITLE
Support .json extensions in require() resolution

### DIFF
--- a/lib/bundle.js
+++ b/lib/bundle.js
@@ -62,7 +62,8 @@ function bundle (input, complete) {
         filter: function (id) {
           if (id == 'nexeres') { return false; } //treat our new moudle as a builtin module
           return !~builtins.indexOf(id);
-        }
+        },
+        extensions: ['.js', '.json' ]
       });
       md.pipe(through(function (chunk) {
         deps.push(chunk);


### PR DESCRIPTION
Embarrassingly simple fix.  Added .json to the list of extensions to search when a require with no extension is found.  

Resolves #57
Resolves #72