### PR TITLE
Lighter weight way to accomplish the exclusion of the sys module

### DIFF
--- a/lib/bundle.js
+++ b/lib/bundle.js
@@ -61,12 +61,11 @@ function bundle (input, complete) {
 
         },
         filter: function (id) {
-          if (id == 'nexeres') { return false; } //treat our new module as a builtin module
+          if ([ 'nexeres', 'sys' ].indexOf(id) > -1) { return false; }
           return !~builtins.indexOf(id);
         },
         extensions: [ '.js', '.json' ],
-        ignoreMissing: true,
-        modules: { sys: __dirname + '/empty.js' }
+        ignoreMissing: true
       });
 
       /** event for missing packages, fixes conditional requires **/


### PR DESCRIPTION
This fixes #71 better.   It's less hacky, and doesn't require the extra empty file.  This also opens the door for adding user specified exclusions down the line. 

 (Like express, which is a honking monster and has been no end of headache to package)