### PR TITLE
Updated version of dependency builtins to 1.0.1 ( inclusion of console to the built in module list )

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "main": "./lib/index.js",
   "dependencies": {
     "async": "^0.9.0",
-    "builtins": "0.0.7",
+    "builtins": "1.0.1",
     "colors": "^1.0.3",
     "glob": "^4.4.0",
     "mkdirp": "^0.5.0",


### PR DESCRIPTION
Was facing an error while using nexe because console was not added to the list of modules returned by builtins, prior to 1.0.1. This PR updates the builtins dependency to 1.0.1.

Fixes #112 